### PR TITLE
Add admin option to unassign desks

### DIFF
--- a/app/routes/desks.$id.edit.tsx
+++ b/app/routes/desks.$id.edit.tsx
@@ -76,17 +76,18 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   let deskId = Number(params.id);
   let formData = await request.formData();
+  let intent = String(formData.get("intent"));
   let updatedUserId = String(formData.get("user-id"))?.toLowerCase();
   let currentUserId = String(formData.get("current-user-id"));
   let currentUserCronId = String(formData.get("current-user-cron-id"));
 
-  if (!updatedUserId) {
+  if (intent !== "unassign" && !updatedUserId) {
     return dataWithError(null, { message: "Invalid user id" });
   }
 
   await db
     .update(desks)
-    .set({ userId: updatedUserId })
+    .set({ userId: intent === "unassign" ? null : updatedUserId })
     .where(eq(desks.id, deskId));
 
   if (currentUserCronId) {
@@ -148,6 +149,17 @@ export default function EditDeskPage({ loaderData }: Route.ComponentProps) {
 
         <Button className="w-full" type="submit" disabled={isSubmitting}>
           Edit
+        </Button>
+
+        <Button
+          className="w-full"
+          type="submit"
+          name="intent"
+          value="unassign"
+          variant="outline"
+          disabled={isSubmitting || !loaderData.user}
+        >
+          Unassign desk
         </Button>
       </Form>
 


### PR DESCRIPTION
### Motivation

- Provide desk admins a one-click way to unassign a desk by clearing the `userId` on the desk record (set to `NULL`) without requiring a replacement user id.

### Description

- Add an `intent` form field to the desk edit action and accept an `intent === "unassign"` path to handle unassignment.
- Update server-side validation so `intent === "unassign"` bypasses the required `user-id` check and sets `userId` to `null` in the `desks` table when unassigning.
- Keep the existing cron cleanup logic for the current user when a desk is unassigned by preserving the `autoReservationsCronId` clearing and `deleteCron` call.
- Add an `Unassign desk` button to the admin desk edit form that submits `intent=unassign` and is disabled when the desk is already unassigned or while submitting.

### Testing

- Ran `npm run typecheck`, which failed in this environment because the local `react-router` CLI is not available (`sh: 1: react-router: not found`).
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed for the same missing `react-router` binary error.
- Attempted `npm ci --legacy-peer-deps` to install dependencies, which produced warnings and long-running output in this environment and could not be used to complete a full local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699197b76c608329957a4a0864f46652)