### PR TITLE
Improve user-facing error messages across reservation flows

### DIFF
--- a/app/components/error-card.tsx
+++ b/app/components/error-card.tsx
@@ -1,10 +1,12 @@
-export function ErrorCard({ message }: { message?: any }) {
+import { getUserFriendlyErrorMessage } from "~/lib/error-messages";
+
+export function ErrorCard({ message }: { message?: unknown }) {
   return (
-    <div className="fixed bg-gray-900/10   inset-0 flex items-center justify-center z-50 px-4">
-      <div className="w-full h-full flex items-center justify-center">
-        <div className="bg-white dark:bg-gray-900 p-6 rounded-lg shadow-lg max-w-md w-full">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/10 px-4">
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg dark:bg-gray-900">
           <div className="flex items-center gap-4">
-            <div className="bg-red-500 text-white rounded-full p-2">
+            <div className="rounded-full bg-red-500 p-2 text-white">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"
@@ -22,9 +24,9 @@ export function ErrorCard({ message }: { message?: any }) {
               </svg>
             </div>
             <div className="space-y-2">
-              <h2 className="text-lg font-medium">An error has ocurred!</h2>
+              <h2 className="text-lg font-medium">An error has occurred</h2>
               <p className="text-gray-500 dark:text-gray-400">
-                {message || "Something went wrong. Please try again later."}
+                {getUserFriendlyErrorMessage(message)}
               </p>
             </div>
           </div>

--- a/app/lib/error-messages.ts
+++ b/app/lib/error-messages.ts
@@ -1,0 +1,30 @@
+type SerializableError = {
+  message?: string;
+};
+
+export function getUserFriendlyErrorMessage(error: unknown) {
+  let rawMessage =
+    typeof error === "string"
+      ? error
+      : typeof error === "object" && error !== null
+        ? ((error as SerializableError).message ?? "")
+        : "";
+
+  if (rawMessage.includes("SQLITE_CONSTRAINT_FOREIGNKEY")) {
+    return "The selected record does not exist anymore. Please refresh and try again.";
+  }
+
+  if (
+    rawMessage.includes("SQLITE_CONSTRAINT_PRIMARYKEY") ||
+    rawMessage.includes("SQLITE_CONSTRAINT_UNIQUE")
+  ) {
+    return "This action conflicts with existing data. Please refresh and try again.";
+  }
+
+  if (!rawMessage) {
+    return "Something went wrong. Please try again later.";
+  }
+
+  return rawMessage;
+}
+

--- a/app/routes/automatic-reservations.tsx
+++ b/app/routes/automatic-reservations.tsx
@@ -1,7 +1,7 @@
 import { PauseIcon, PlayIcon, TrashIcon } from "@radix-ui/react-icons";
 import { and, eq } from "drizzle-orm";
 import { Form, redirect, useNavigation } from "react-router";
-import { dataWithSuccess } from "remix-toast";
+import { dataWithError, dataWithSuccess } from "remix-toast";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { requireAuthCookie } from "~/cookies.server";
@@ -70,9 +70,11 @@ export async function action({ request }: Route.ActionArgs) {
     });
 
     if (!parsedInput.success) {
-      throw new Error(
-        "Invalid form input, please try again! If the issue persists contact an admin.",
-      );
+      return dataWithError(null, {
+        message: "Invalid automatic reservation setup",
+        description:
+          "Please choose at least one day and try again. If the issue persists, contact an admin.",
+      });
     }
 
     let res = await addCron(parsedInput.data);


### PR DESCRIPTION
### Motivation
- Replace generic "unexpected"/opaque errors with actionable, user-friendly messages so users understand why operations (like desk assignment or reservation creation) fail. 
- Surface readable feedback for common DB constraint failures (e.g. foreign key / uniqueness) instead of raw SQLite error text.
- Prevent confusing crashes caused by thrown generic errors and provide consistent toast/error UI messaging.

### Description
- Add a shared helper `getUserFriendlyErrorMessage` in `app/lib/error-messages.ts` that maps common SQLite constraint messages to friendly text and falls back to sensible defaults. 
- Update the global error UI `ErrorCard` (`app/components/error-card.tsx`) to use `getUserFriendlyErrorMessage` and fix wording in the heading. 
- Improve desk assignment flow (`app/routes/desks.$id.edit.tsx`) by validating the target user exists before assigning and catching DB update errors to return a friendly `dataWithError` with descriptive text. 
- Improve reservation flow (`app/routes/reserve.$.tsx`) to catch insertion failures and return `dataWithError` with a user-friendly description. 
- Replace a thrown generic `Error` in `app/routes/automatic-reservations.tsx` with a structured `dataWithError` validation message for invalid setup input.

### Testing
- Ran `npm run typecheck` which failed in this environment because the `react-router` binary is not available in local `node_modules`. 
- Ran `npx tsc --noEmit` which failed due to missing project type definitions from installed dependencies in this environment. 
- Attempted `npm install --legacy-peer-deps` to populate deps for type checks, but dependency peer warnings/conflicts were observed and full type validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e18ad5788329a41aa9052f124547)